### PR TITLE
Added imports for python 3 compatibility

### DIFF
--- a/nervanagpu/__init__.py
+++ b/nervanagpu/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .nervanagpu import NervanaGPU, GPUTensor
+from .nervanagpu import NervanaGPU, GPUTensor, _contiguous_strides, _get_events

--- a/nervanagpu/float_ew.py
+++ b/nervanagpu/float_ew.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-
 import os.path
 import re
 import traceback as tb
@@ -22,7 +20,7 @@ from pycuda.compiler import SourceModule
 from pycuda.tools import context_dependent_memoize
 from pytools import memoize, memoize_method
 import pycuda.driver as drv
-from nervanagpu import nervanagpu as ng
+import nervanagpu as ng
 # from ipdb import set_trace
 
 _ew_template = r"""

--- a/nervanagpu/float_ew.py
+++ b/nervanagpu/float_ew.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
+
 import os.path
 import re
 import traceback as tb
@@ -20,7 +22,7 @@ from pycuda.compiler import SourceModule
 from pycuda.tools import context_dependent_memoize
 from pytools import memoize, memoize_method
 import pycuda.driver as drv
-import nervanagpu as ng
+from nervanagpu import nervanagpu as ng
 # from ipdb import set_trace
 
 _ew_template = r"""


### PR DESCRIPTION
float_ew was calling a couple of functions from nervanagpu that weren't being imported in python 3. I added them to the list of imports in __init__.py

